### PR TITLE
Fixed missing support for fullMessages: false in validate.async

### DIFF
--- a/specs/validate-async-spec.js
+++ b/specs/validate-async-spec.js
@@ -64,6 +64,16 @@ describe("validate.async", function() {
     });
   });
 
+  it.promise("supports fullMessages: false", function() {
+    var c = {name: {presence: true}};
+    return validate.async({}, c, {fullMessages: false}).then(success, error).then(function() {
+      expect(success).not.toHaveBeenCalled();
+      expect(error).toHaveBeenCalledWith({
+        name: ["can't be blank"]
+      });
+    });
+  });
+
   describe("Promise", function() {
     var globals = ["Promise", "Q", "when", "RSVP"]
       , store = {};

--- a/validate.js
+++ b/validate.js
@@ -130,7 +130,7 @@
 
       return v.Promise(function(resolve, reject) {
         v.waitForResults(results).then(function() {
-          var errors = v.processValidationResults(results);
+          var errors = v.processValidationResults(results, options);
           if (errors) {
             reject(errors);
           } else {


### PR DESCRIPTION
Hi!

The `options` were never passed into `processValidationResults`, where it checks whether the `fullMessages` flag has been set to `false`.
