### PR TITLE
Values without property length would pass validation

### DIFF
--- a/specs/validators/length-spec.js
+++ b/specs/validators/length-spec.js
@@ -70,6 +70,16 @@ describe('validator.length', function() {
     expect(length(undefined, options)).not.toBeDefined();
   });
 
+  it("refuses value without length property", function() {
+    var options = {is: 10, minimum: 20, maximum: 5};
+    expect(length(3.1415, options)).toBeDefined();
+    expect(length(-3.1415, options)).toBeDefined();
+    expect(length(0, options)).toBeDefined();
+    expect(length({}, options)).toBeDefined();
+    expect(length({lengthi: 10}, options)).toBeDefined();
+    expect(length(3, {})).toBeDefined();
+  });
+
   // This test is not a real life example, specifying is with anything else
   // is just weird but hey.
   it("allows you to specify is, minimum and maximum", function() {

--- a/validate.js
+++ b/validate.js
@@ -533,21 +533,27 @@
         , errors = [];
 
       value = tokenizer(value);
+      var length = value.length;
+      if(!v.isDefined(length)) {
+        length = 0;
+        // make sure at least minimum fails if `is` is not defined
+        minimum = minimum || (!v.isNumber(is) && 1);
+      }
 
       // Is checks
-      if (v.isNumber(is) && value.length !== is) {
+      if (v.isNumber(is) && length !== is) {
         err = options.wrongLength ||
           "is the wrong length (should be %{count} characters)";
         errors.push(v.format(err, {count: is}));
       }
 
-      if (v.isNumber(minimum) && value.length < minimum) {
+      if (v.isNumber(minimum) && length < minimum) {
         err = options.tooShort ||
           "is too short (minimum is %{count} characters)";
         errors.push(v.format(err, {count: minimum}));
       }
 
-      if (v.isNumber(maximum) && value.length > maximum) {
+      if (v.isNumber(maximum) && length > maximum) {
         err = options.tooLong ||
           "is too long (maximum is %{count} characters)";
         errors.push(v.format(err, {count: maximum}));


### PR DESCRIPTION
fix bug where value with no length would pass validation with length required
