### PR TITLE
Allow custom messages on numericality options object for each validation

### DIFF
--- a/specs/validators/numericality-spec.js
+++ b/specs/validators/numericality-spec.js
@@ -45,6 +45,12 @@ describe("validators.numericality", function() {
     expect(numericality("foo", {message: "my message"})).toEqual("my message");
   });
 
+  it("uses the custom message if specified", function() {
+    var expected = "default message";
+    expect(numericality("foo", {notValid: expected})).toEqual("default message");
+    expect(numericality("foo", {message: "my message"})).toEqual("my message");
+  });
+
   describe("onlyInteger", function() {
     it("allows integers", function() {
       expect(numericality(1, {onlyInteger: true})).not.toBeDefined();
@@ -64,6 +70,11 @@ describe("validators.numericality", function() {
       opts.message = "my message";
       expect(numericality(3.14, opts)).toEqual("my message");
     });
+
+    it("uses the custom message if specified", function() {
+      var opts = {onlyInteger: true, notInteger: "default message" };
+      expect(numericality(3.14, opts)).toEqual("default message");
+    });
   });
 
   describe("greaterThan", function() {
@@ -75,6 +86,11 @@ describe("validators.numericality", function() {
       var expected = ["must be greater than 3.14"];
       expect(numericality(3.14, {greaterThan: 3.14})).toEqual(expected);
       expect(numericality(2.72, {greaterThan: 3.14})).toEqual(expected);
+    });
+
+    it("allows for a custom message", function() {
+      var expected = "custom message";
+      expect(numericality(3.14, {greaterThan: 3.14, notGreaterThan: expected})).toEqual([expected]);
     });
 
     it("allows for a default message", function() {
@@ -93,6 +109,11 @@ describe("validators.numericality", function() {
     it("doesn't allow numbers that are smaller than", function() {
       var expected = ["must be greater than or equal to 3.14"];
       expect(numericality(2.72, {greaterThanOrEqualTo: 3.14})).toEqual(expected);
+    });
+
+    it("allows for a custom message", function() {
+      var expected = "custom message";
+      expect(numericality(3.13, {greaterThanOrEqualTo: 3.14, notGreaterThanOrEqualTo: expected})).toEqual([expected]);
     });
 
     it("allows for a default message", function() {
@@ -117,6 +138,11 @@ describe("validators.numericality", function() {
       validate.validators.numericality.notEqualTo = expected;
       expect(numericality(3.13, {equalTo: 3.14})).toEqual([expected]);
     });
+
+    it("allows for a custom message", function() {
+      var expected = "custom message";
+      expect(numericality(3.13, {equalTo: 3.14, notEqualTo:expected})).toEqual([expected]);
+    });
   });
 
   describe("lessThan", function() {
@@ -135,6 +161,11 @@ describe("validators.numericality", function() {
       validate.validators.numericality.notLessThan = expected;
       expect(numericality(3.14, {lessThan: 3.14})).toEqual([expected]);
     });
+
+    it("allows for a custom message", function() {
+      var expected = "custom message";
+      expect(numericality(3.14, {lessThan: 3.14, notLessThan: expected})).toEqual([expected]);
+    });
   });
 
   describe("lessThanOrEqualTo", function() {
@@ -152,6 +183,11 @@ describe("validators.numericality", function() {
       var expected = "default message";
       validate.validators.numericality.notLessThanOrEqualTo = expected;
       expect(numericality(3.15, {lessThanOrEqualTo: 3.14})).toEqual([expected]);
+    });
+
+    it("allows for a custom message", function() {
+      var expected = "custom message";
+      expect(numericality(3.15, {lessThanOrEqualTo: 3.14, notLessThanOrEqualTo: expected})).toEqual([expected]);
     });
   });
 
@@ -174,6 +210,11 @@ describe("validators.numericality", function() {
       validate.validators.numericality.notOdd = expected;
       expect(numericality(2, {odd: true})).toEqual([expected]);
     });
+
+    it("allows for a custom message", function() {
+      var expected = "custom message";
+      expect(numericality(2, {odd: true, notOdd: expected})).toEqual([expected]);
+    });
   });
 
   describe("even", function() {
@@ -194,6 +235,11 @@ describe("validators.numericality", function() {
       var expected = "default message";
       validate.validators.numericality.notEven = expected;
       expect(numericality(3, {even: true})).toEqual([expected]);
+    });
+
+    it("allows for a custom message", function() {
+      var expected = "custom message";
+      expect(numericality(3, {even: true, notEven: expected})).toEqual([expected]);
     });
   });
 

--- a/validate.js
+++ b/validate.js
@@ -605,13 +605,13 @@
 
       // If it's not a number we shouldn't continue since it will compare it.
       if (!v.isNumber(value)) {
-        return options.message || this.notValid || "is not a number";
+        return options.message || options.notValid || this.notValid || "is not a number";
       }
 
       // Same logic as above, sort of. Don't bother with comparisons if this
       // doesn't pass.
       if (options.onlyInteger && !v.isInteger(value)) {
-        return options.message || this.notInteger  || "must be an integer";
+        return options.message || options.notInteger || this.notInteger  || "must be an integer";
       }
 
       for (name in checks) {
@@ -620,8 +620,8 @@
           // This picks the default message if specified
           // For example the greaterThan check uses the message from
           // this.notGreaterThan so we capitalize the name and prepend "not"
-          var msg = this["not" + v.capitalize(name)] ||
-            "must be %{type} %{count}";
+          var key = "not" + v.capitalize(name);
+          var msg = options[key] || this[key] || "must be %{type} %{count}";
 
           errors.push(v.format(msg, {
             count: count,
@@ -631,10 +631,10 @@
       }
 
       if (options.odd && value % 2 !== 1) {
-        errors.push(this.notOdd || "must be odd");
+        errors.push(options.notOdd || this.notOdd || "must be odd");
       }
       if (options.even && value % 2 !== 0) {
-        errors.push(this.notEven || "must be even");
+        errors.push(options.notEven || this.notEven || "must be even");
       }
 
       if (errors.length) {


### PR DESCRIPTION
In the same way that I am able to custom validation messages to the length validator options object - for example: (wrongLength, tooLong, tooShort) -  I want to add custom messages on the options object to the of numericality validator. 

validate.validators.numericality.notGreaterThan sets a default value. I need a custom message which is different for the same validations (numericality, greater than X) but with a completely different message. 

Include changes to numericality-spec.js

Totally up for providing examples and text for validate.js documentation if desired. 

