### PR TITLE
Tests showing how dotted notation needs to be handled

### DIFF
--- a/specs/validate-spec.js
+++ b/specs/validate-spec.js
@@ -79,13 +79,42 @@ describe("validate", function() {
     ]);
   });
 
-  it("works with nested objects set to null", function() {
+  it("fails validation when nested objects is null", function() {
     var constraints = {
       "foo.bar": {
         presence: true
       }
     };
     expect(validate({foo: null}, constraints)).toBeDefined();
+  });
+
+  it("works with nested objects", function() {
+    var constraints = {
+      "foo.bar": {
+        presence: true
+      }
+    };
+    expect(validate({foo: {bar: "test"}}, constraints)).not.toBeDefined();
+  });
+
+  it("works with dotted notation", function() {
+    var constraints = {
+      "foo\\.bar": {
+        presence: true
+      }
+    };
+    expect(validate({"foo.bar": "test"}, constraints)).not.toBeDefined();
+  });
+
+  it("formats validation entries nicely on dotted notation", function() {
+    var constraints = {
+      "foo\\.bar": {
+        presence: true
+      }
+    };
+    expect(validate({"foo.bar": null}, constraints)).toEqual({
+      "foo\\.bar": ["Foo bar can't be blank"]
+    });
   });
 
   describe("runValidations", function() {


### PR DESCRIPTION
Hi,

This is meant as a code-example for issue #46. This adds tests showing how dotted notation must be phrased to avoid the "nested object" parsing. I'd prefer an explicit feature to support dotted notation properly rather than the code shown in this PR though.