### PR TITLE
adding `wrapErrors` options for wrapping errors into error class

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -170,7 +170,9 @@
           throw new Error(v.format("Unknown format %{format}", options));
       }
 
-      return v.isEmpty(errors) ? undefined : errors;
+      var resp = v.isEmpty(errors) ? undefined : errors;
+
+      return resp && options.wrapErrors ? new options.wrapErrors(resp) : resp;
     },
 
     // Runs the validations with support for promises.


### PR DESCRIPTION
Super simple solution for https://github.com/ansman/validate.js/issues/51.

Example:

```js
// ./validate.js

var validate = require('validate.js');
var ValidationError = require('../errors/validation_error');

validate.Promise = require('bluebird');
validate.options = validate.async.options = {
  fullMessages: false,
  wrapErrors: ValidationError
};

module.exports = validate;
```

```js
// ./validation_error

module.exports = function ValidationError(params, message, options) {
  Error.captureStackTrace(this, this.constructor);
  this.name = this.constructor.name;
  this.params = params;
  this.message = message || 'Validation Error';
  this.options = options;
};

require('util').inherits(module.exports, Error);
```

```js
// ./index.js

var validate = require('./validate');
var ValidationError = require('./validation_error');

var data = {
  name: ''
};
var contraints = {
  name: { presence: true, length: { minimum: 10 } }
};

validate.async(data, contraints).then(function() {
  console.log('ok');
}).catch(ValidationError, function(err) {
  console.log('ValidationError', err);
}).catch(function(err) {
  console.log('SystemError', err);
});

```

Run as
```
node index.js
```