### PR TITLE
Add skipPresence option.

### DIFF
--- a/specs/validate-spec.js
+++ b/specs/validate-spec.js
@@ -171,6 +171,25 @@ describe("validate", function() {
       ]);
     });
 
+    it("allows skipPresence option", function () {
+      var constraints = {
+        attr1: {pass: true, presence: true},
+        attr2: {presence: true},
+      };
+      spyOn(validate.validators, "presence").and.callThrough();
+      expect(validate.runValidations({}, constraints, {skipPresence: true})).toHaveItems([
+        {
+          attribute: 'attr1',
+          value: undefined,
+          validator: 'pass',
+          options: true,
+          error: undefined
+        }
+      ]);
+      expect(validate.validators.presence).not.toHaveBeenCalledWith('attr1');
+      expect(validate.validators.presence).not.toHaveBeenCalledWith('attr2');
+    });
+
     it("allows the options for an attribute to be a function", function() {
       var options = {pass: {option1: "value1"}}
         , attrs = {name: "Nicklas"}

--- a/validate.js
+++ b/validate.js
@@ -116,6 +116,10 @@
             throw new Error(error);
           }
 
+          if (options.skipPresence && validatorName === 'presence') {
+            continue;
+          }
+
           validatorOptions = validators[validatorName];
           // This allows the options to be a function. The function will be
           // called with the value, attribute name, the complete dict of


### PR DESCRIPTION
Hi,

This is a PR to add a `skipPresence` options to `validate`.
This is useful to validate data on update.

For example, this would allow to write something like this.

```
var options = {};
if (request.method === 'PUT') {
  options.skipPresence = true;
}
validate(request.body, constraints, options);
```

Thanks.