### PR TITLE
add attribute label support

### DIFF
--- a/specs/validate-helpers-spec.js
+++ b/specs/validate-helpers-spec.js
@@ -401,6 +401,36 @@ describe("validate", function() {
       }]);
     });
 
+    it("use the attributes label if it's specified in options", function() {
+      var errors = [{
+        attribute: "foo",
+        error: "can't be blank",
+        someOtherProperty: "someOtherProperty",
+        value: "foobar"
+      }, {
+        attribute: "foo_bar",
+        error: "has some other problem",
+        value: "foobar"
+      }];
+
+      var options = {
+          labels: {
+              foo: 'foo label'
+          }
+      };
+
+      expect(convertErrorMessages(errors, options)).toEqual([{
+        attribute: "foo",
+        error: "Foo label can't be blank",
+        someOtherProperty: "someOtherProperty",
+        value: "foobar"
+      }, {
+        attribute: "foo_bar",
+        error: "Foo bar has some other problem",
+        value: "foobar"
+      }]);
+    });
+
     it("doesn't modify the input", function() {
       var errors = [{
         attribute: "foo",

--- a/validate.js
+++ b/validate.js
@@ -429,6 +429,14 @@
         .toLowerCase();
     },
 
+    attributeLabel: function(attribute, options) {
+        var label = v.isObject(options) &&
+          v.isObject(options.labels) &&
+          options.labels[attribute];
+
+        return label || v.prettify(attribute);
+    },
+
     stringifyValue: function(value) {
       return v.prettify(value);
     },
@@ -641,7 +649,8 @@
         if (error[0] === '^') {
           error = error.slice(1);
         } else if (options.fullMessages !== false) {
-          error = v.capitalize(v.prettify(errorInfo.attribute)) + " " + error;
+		  var label = v.attributeLabel(errorInfo.attribute, options);
+          error = v.capitalize(label) + " " + error;
         }
         error = error.replace(/\\\^/g, "^");
         error = v.format(error, {value: v.stringifyValue(errorInfo.value)});
@@ -1009,7 +1018,7 @@
     }, {
       PATTERN: /^[a-z0-9\u007F-\uffff!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9\u007F-\uffff!#$%&'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/i
     }),
-    equality: function(value, options, attribute, attributes) {
+    equality: function(value, options, attribute, attributes, globalOptions) {
       if (v.isEmpty(value)) {
         return;
       }
@@ -1032,7 +1041,7 @@
         };
 
       if (!comparator(value, otherValue, options, attribute, attributes)) {
-        return v.format(message, {attribute: v.prettify(options.attribute)});
+        return v.format(message, {attribute: v.attributeLabel(options.attribute, globalOptions)});
       }
     },
 


### PR DESCRIPTION
Hi, I've implemented support for attribute label, which when used is printed in the error messages instead of "pretiffied" attribute name (see https://github.com/ansman/validate.js/issues/69#issuecomment-194771733). I have updated tests, but maybe didn't cover the code completely. I didn't updated doc. Finally I've used another validation library, so I don't rely on this anymore, but I don't want throw away the work. If you found my implementation useful, here it is, if not, just delete the PR.