### PR TITLE
feat(util): Add isHash utility

### DIFF
--- a/specs/validate-helpers-spec.js
+++ b/specs/validate-helpers-spec.js
@@ -225,6 +225,22 @@ describe("validate", function() {
     });
   });
 
+  describe('isHash', function() {
+    it("returns true for hashes", function() {
+      expect(validate.isHash({})).toBe(true);
+      expect(validate.isHash({foo: "bar"})).toBe(true);
+    });
+
+    it("returns false for non hashes", function() {
+      expect(validate.isHash([])).toBe(false);
+      expect(validate.isHash(function() {})).toBe(false);
+      expect(validate.isHash(null)).toBe(false);
+      expect(validate.isHash(1)).toBe(false);
+      expect(validate.isHash("")).toBe(false);
+      expect(validate.isHash(false)).toBe(false);
+    });
+  });
+
   describe('contains', function() {
     var contains = validate.contains;
 

--- a/validate.js
+++ b/validate.js
@@ -441,6 +441,12 @@
       return {}.toString.call(value) === '[object Array]';
     },
 
+    // Checks if the object is a hash, which is equivalent to an object that
+    // is neither an array nor a function.
+    isHash: function(value) {
+      return v.isObject(value) && !v.isArray(value) && !v.isFunction(value);
+    },
+
     contains: function(obj, value) {
       if (!v.isDefined(obj)) {
         return false;


### PR DESCRIPTION
`isHash` is a utility function that checks if something is an object,
but is neither an array nor a function.

Closes #110