### PR TITLE
fix incorrect module build, no module name error

### DIFF
--- a/specs/validate-helpers-spec.js
+++ b/specs/validate-helpers-spec.js
@@ -641,8 +641,7 @@ describe("validate", function() {
 
     it("supports AMD", function() {
       var root = {}
-        , define = function(deps, func) {
-          expect(deps).toEqual([]);
+        , define = function(func) {
           expect(func()).toBe(validate);
         };
 

--- a/validate.js
+++ b/validate.js
@@ -745,7 +745,7 @@
       } else {
         root.validate = validate;
         if (validate.isFunction(define) && define.amd) {
-          define([], function () { return validate; });
+          define(function () { return validate; });
         }
       }
     },


### PR DESCRIPTION
Hi,

Added a fix to work with [almond](https://github.com/requirejs/almond) based on this [workaround](https://github.com/requirejs/almond/blob/master/README.md#incorrect-module-build-no-module-name)
