### PR TITLE
Fix broken flow through runValidations in IE8

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -313,7 +313,7 @@
         return false;
       }
 
-      if (!v.isFunction(o.querySelectorAll) || !v.isFunction(o.querySelector)) {
+      if (!o.querySelectorAll || !o.querySelector) {
         return false;
       }
 


### PR DESCRIPTION
Hi,

I am aware that you don't officially support IE8, but I have got validate.js up and running perfectly by including various polyfills for the bits of missing JS functionality.

The only blocker to it running however was a test in the `runValidations` function which checks if `attributes` is a dom element (`isDomElement`). It was doing this by checking if `querySelectorAll` and `querySelector` had a type of function. The issue is that IE8 actually returns a type of 'object' for these native functions (See http://stackoverflow.com/questions/12933625/typeof-in-ie-8-for-native-functions). Therefore I have tweaked this test to merely check for the _presence_ of these methods on the object and not to check on their type. I feel that it is reasonable to assume that if they are present, that they will be the native methods or something that functions equivalently (e.g. a polyfill) and that testing their type doesn't add any significant value.

What are your thoughts? As I say, this small tweak allows the library to run nicely under IE8 (provided you polyfill things like `Array.prototype.forEach` and a few others) without diminishing functionality in modern browsers.