### PR TITLE
Fix #2: add support for custom validators

### DIFF
--- a/specs/validate-spec.js
+++ b/specs/validate-spec.js
@@ -243,6 +243,18 @@ describe("validate", function() {
         {}
       );
     });
+
+    it("supports custom validators in the constraints schema", function() {
+      var attributes = {name: "Nicklas"}
+        , customValidator = jasmine.createSpy("validator").and.returnValue("some error message")
+        , constraints = {name: {someCustomValidator: customValidator}}
+        , options = {option1: "value1"};
+
+      expect(validate(attributes, constraints, options)).toEqual(
+        {name: ["Name some error message"]}
+      );
+      expect(customValidator).toHaveBeenCalledWith("Nicklas", options, "name", attributes);
+    });
   });
 
   describe("format", function() {

--- a/specs/validate-spec.js
+++ b/specs/validate-spec.js
@@ -244,16 +244,40 @@ describe("validate", function() {
       );
     });
 
-    it("supports custom validators in the constraints schema", function() {
-      var attributes = {name: "Nicklas"}
-        , customValidator = jasmine.createSpy("validator").and.returnValue("some error message")
-        , constraints = {name: {someCustomValidator: customValidator}}
-        , options = {option1: "value1"};
+    describe("custom validators in the constraints schema", function() {
+      describe("grouped format", function() {
+        it("is supported", function() {
+          var attributes = {name: "Nicklas"}
+            , customValidator = jasmine.createSpy("validator").and.returnValue("some error message")
+            , constraints = {name: {someCustomValidator: customValidator}}
+            , options = {format: "grouped"};
 
-      expect(validate(attributes, constraints, options)).toEqual(
-        {name: ["Name some error message"]}
-      );
-      expect(customValidator).toHaveBeenCalledWith("Nicklas", options, "name", attributes);
+          expect(validate(attributes, constraints, options)).toEqual(
+            {name: ["Name some error message"]}
+          );
+          expect(customValidator).toHaveBeenCalledWith("Nicklas", options, "name", attributes);
+        });
+      });
+
+      describe("detailed format", function() {
+        it("is supported", function() {
+          var attributes = {name: "Nicklas"}
+            , customValidator = jasmine.createSpy("validator").and.returnValue("some error message")
+            , constraints = {name: {someCustomValidator: customValidator}}
+            , options = {format: "detailed"};
+
+          expect(validate(attributes, constraints, options)).toEqual([{
+            attribute: "name",
+            value: "Nicklas",
+            validator: "someCustomValidator",
+            globalOptions: options,
+            attributes: attributes,
+            options: "some error message", // <-- NOTE: is this expected?
+            error: "Name some error message"
+          }]);
+          expect(customValidator).toHaveBeenCalledWith("Nicklas", options, "name", attributes);
+        });
+      });
     });
   });
 

--- a/validate.js
+++ b/validate.js
@@ -106,14 +106,13 @@
         validators = v.result(constraints[attr], value, attributes, attr, options, constraints);
 
         for (validatorName in validators) {
-          validator = v.validators[validatorName];
+          validatorOptions = validators[validatorName];
+          validator = v.validators[validatorName] || buildCustomValidator(validatorOptions);
 
           if (!validator) {
             error = v.format("Unknown validator %{name}", {name: validatorName});
             throw new Error(error);
           }
-
-          validatorOptions = validators[validatorName];
           // This allows the options to be a function. The function will be
           // called with the value, attribute name, the complete dict of
           // attributes as well as the options and constraints passed in.
@@ -1122,6 +1121,23 @@
       return errors;
     }
   };
+
+  /**
+   * Build a custom validator from the given function (if one is given)
+   *
+   * Allows for ad-hoc validators to be defined directly in the constraints
+   * schema. Please see: https://github.com/ansman/validate.js/issues/2
+   *
+   * @param  {*} fn
+   * @return {Function|undefined}
+   */
+  function buildCustomValidator(fn) {
+    if (typeof fn !== 'function') { return; }
+
+    return function(value, validatorOptions, attr, attributes, options) {
+      return fn(value, options, attr, attributes);
+    };
+  }
 
   validate.exposeModule(validate, this, exports, module, define);
 }).call(this,


### PR DESCRIPTION
Allow for ad-hoc validators to be defined directly in the constraints schema.

Thanks for considering this contribution!
