### PR TITLE
Alias 'presence' validator as 'required'

### DIFF
--- a/specs/validators/presence-spec.js
+++ b/specs/validators/presence-spec.js
@@ -50,4 +50,11 @@ describe('validator.presence', function() {
       , value = null;
     expect(presence(value, options)).toBe(message);
   });
+
+  it("is aliased as 'required'", function() {
+    var required = validate.validators.required.bind(validate.validators.required);
+    var msg = required(null, {});
+    expect(validate.validators.required).toEqual(validate.validators.presence);
+    expect(msg).toEqual("can't be blank");
+  });
 });

--- a/validate.js
+++ b/validate.js
@@ -1121,6 +1121,9 @@
     }
   };
 
+  // Alias presence validator as 'required'
+  validate.validators.required = validate.validators.presence;
+
   validate.formatters = {
     detailed: function(errors) {return errors;},
     flat: v.flattenErrorsToArray,


### PR DESCRIPTION
Now personally, I don't mind that the original validator is named `presence`, but my co-workers are a tad antsy about their validation rules not matching what they're used to in other frameworks.

So I thought it would be handy to have an alias named `required`, for those who are more accustomed to writing validation that way, or prefer something a little harder to mis-type ("presense"/"precense").
