### PR TITLE
empty strings valid for email

### DIFF
--- a/specs/validators/email-spec.js
+++ b/specs/validators/email-spec.js
@@ -28,12 +28,12 @@ describe('validators.email', function() {
     expect(email('other.email-with-dash@example.com', {})).not.toBeDefined();
     expect(email('üñîçøðé@example.com', {})).not.toBeDefined();
     expect(email("foo@some.customtld", {})).not.toBeDefined();
+    expect(email("", {})).not.toBeDefined();
+    expect(email(" ", {})).not.toBeDefined();
   });
 
   it("doesn't allow 'invalid' emails", function() {
     var expected = "is not a valid email";
-    expect(email("", {})).toEqual(expected);
-    expect(email(" ", {})).toEqual(expected);
     expect(email("foobar", {})).toEqual(expected);
     expect(email("foo@bar", {})).toEqual(expected);
 

--- a/validate.js
+++ b/validate.js
@@ -1042,6 +1042,9 @@
       if (!v.isString(value)) {
         return message;
       }
+      if (v.isEmpty(value)) {
+        return;
+      }
       if (!this.PATTERN.exec(value)) {
         return message;
       }


### PR DESCRIPTION
https://validatejs.org/#validators-email says empty or whitespace only strings are valid