### PR TITLE
correct an issue with IE 11

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -563,7 +563,7 @@
           value = [];
           for (j in input.options) {
             option = input.options[j];
-            if (option.selected) {
+             if (option && option.selected) {
               value.push(v.sanitizeFormValue(option.value, options));
             }
           }


### PR DESCRIPTION
in IE 11 11.447.14393.0 input.options returns an array of every attribute on the option element, there is an open issue (#181) detailing this.