### PR TITLE
[WIP] Add array support with any constraints

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -611,6 +611,11 @@
     expandMultipleErrors: function(errors) {
       var ret = [];
       errors.forEach(function(error) {
+        if (v.isFunction(error.error.expand)) {
+          error.error.expand(ret, error);
+          return;
+        }
+
         // Removes errors without a message
         if (v.isArray(error.error)) {
           error.error.forEach(function(msg) {
@@ -1144,6 +1149,68 @@
       if (!PATTERN.exec(value)) {
         return message;
       }
+    },
+
+    forEachSingle: function(value, options, attribute, attributes) {
+      if (!v.isDefined(value)) {
+        return;
+      }
+
+      var result = {
+        expand: function(ret, res) {
+          res.error.data.forEach(function(ary, i) {
+            if (ary) {
+              ary.forEach(function(r) {
+                var attribute = res.attribute + '[' + i + ']';
+                var o = v.extend({}, r, {
+                  attribute: attribute,
+                  attributes: {}
+                });
+                o.attributes[attribute] = r.attributes.single;
+                ret.push(o);
+              });
+            }
+          });
+        },
+        data: []
+      };
+      for (var i = 0; i < value.length; i++) {
+        var r = v({single: value[i]}, {single: options},
+                  {fullMessages: false, format: 'detailed'});
+        result.data.push(r);
+      }
+      return result;
+    },
+
+    forEach: function(value, options, attribute, attributes) {
+      if (!v.isDefined(value)) {
+        return;
+      }
+
+      var result = {
+        expand: function(ret, res) {
+          res.error.data.forEach(function(ary, i) {
+            if (ary) {
+              ary.forEach(function(r) {
+                var attribute = res.attribute + '[' + i + '].' + r.attribute;
+                var o = v.extend({}, r, {
+                  attribute: attribute,
+                  attributes: {}
+                });
+                o.attributes[attribute] = r.attributes;
+                ret.push(o);
+              });
+            }
+          });
+        },
+        data: []
+      };
+      for (var i = 0; i < value.length; i++) {
+        var r = v(value[i], options,
+                  {fullMessages: false, format: 'detailed'});
+        result.data.push(r);
+      }
+      return result;
     }
   };
 


### PR DESCRIPTION
I implemented `forEach` validator and `forEachSingle` validator. We can specify any constraints for each array element.

# Why [WIP]?

This pull-request is WIP (work in progress), because I want you to check following:

* Adds validator specification about return value. (Any other ideas to implement array support are welcome)
* Adds multiple words validator name, but current master has only single word validator name. (Maybe you want to change validator name to `foreach`)
* And other your requests. implementation, validator name, and so on.

After you accept them, I will create tests, `git push` it and remove [WIP] mark.

# `forEach` validator

This validator checks object properties in array element.

Sample:

```js
validate({
  users: [
    {id: -1, name: 'foo'},
    {id: 1, name: '西田雄也'}
  ]
}, {
  users: {
    forEach: {
      id: {numericality: {greaterThan: 0}},
      name: {format: /^[a-zA-Z0-9]+$/}
    }
  }
})
//=> {"users[0].id":["Users[0] id must be greater than 0"],"users[1].name":["Users[1] name is invalid"]}
```

This is following requests implementation:

* https://github.com/ansman/validate.js/issues/1#issuecomment-153413241
* https://github.com/ansman/validate.js/issues/104

I think this validator name is `forEach` and it is better than `each`. I thought following:

* Currently validate.js has `forEachKeyInKeypath`.
* ECMAScript 2016 uses `forEach` (`Array.prototype.forEach`), and it doesn't use `each`. http://www.ecma-international.org/ecma-262/7.0/#sec-array.prototype.foreach

# `forEachSingle` validator

This validator checks object in array element like `validateSingle` function.

Sample:

```js
validate({ary: ['foo', '', 'tooLongString']}, {
  ary: {
    forEachSingle: {
      presence: true,
      length: {
        maximum: 3
      }
    }
  }
})
//=> {"ary[1]":["Ary[1] can't be blank"],"ary[2]":["Ary[2] is too long (maximum is 3 characters)"]}
```
