### PR TITLE
make validate type any and export as a commonjs module

### DIFF
--- a/validate.d.ts
+++ b/validate.d.ts
@@ -1,9 +1,3 @@
-export declare interface ValidateJS {
-  (attributes: any, constraints: any, options?: any): any;
-  async(attributes: any, constraints: any, options?: any): Promise<any>;
-  single(value: any, constraints: any, options?: any): any;
-}
+declare var validate: any;
 
-declare var validate: ValidateJS;
-
-export default validate;
+export = validate;


### PR DESCRIPTION
Existing typescript definition cripples typescript experience due to it not exporting big chunk of the `validate.js` API such as `validate.extend`. Current definition is not useful either.

`validate.js` is a commonjs module that should be imported either as `const validate = require('validate.js')` or `import * as validate from 'validate.js'`. Thus `export default` makes zero sense and in its current state, it is not importable.

This is a breaking change.