### PR TITLE
add test for nested object validation

### DIFF
--- a/specs/validate-spec.js
+++ b/specs/validate-spec.js
@@ -79,6 +79,15 @@ describe("validate", function() {
     ]);
   });
 
+  it("validates nested objects as expected", function() {
+    var constraints = {
+      "foo.bar": {
+        presence: true
+      }
+    };
+    expect(validate({foo: {bar: ''}}, constraints)).toBeDefined();
+  });
+
   it("works with nested objects set to null", function() {
     var constraints = {
       "foo.bar": {


### PR DESCRIPTION
This test is currently failing in `master`. It passes in `v0.11.1`.