### PR TITLE
Added Support for Syncronous Testing of Promise Presence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 lcov.info
 coverage*
 _SpecRunner.html
+*.komodoproject

--- a/validate.js
+++ b/validate.js
@@ -17,6 +17,7 @@
   //     * grouped - Returns the messages grouped by attribute (default)
   //     * detailed - Returns an array of the raw validation data
   //   - fullMessages (boolean) - If `true` (default) the attribute name is prepended to the error.
+  //   - allowPromises (boolean) - If `true` no error will be thrown if a promise is passed as an attribute.
   //
   // Please note that the options are also passed to each validator.
   var validate = function(attributes, constraints, options) {
@@ -28,7 +29,7 @@
 
     for (attr in results) {
       for (validator in results[attr]) {
-        if (v.isPromise(results[attr][validator])) {
+        if (v.isPromise(results[attr][validator]) && !options.allowPromises) {
           throw new Error("Use validate.async if you want support for promises");
         }
       }


### PR DESCRIPTION
While the resolution of a promise is clearly an asynchronous thing, testing for the presence of a promise is not, so it should be possible to test whether or not a given value is a promise using `validate()` or `validate.single()`.

This very small commit makes that possible by adding an option `allowPromises` to `validate()`.

The following console output from `node` run from the project root folder shows the proposed change in action:

```
cc-dsk-2ss:validate.js bart$ node
> let validate = require('./');
undefined
> // create a custom promise validator
undefined
> validate.validators.promise = function(val, opts){
...     // implicitly pass empty values
...     if(!validate.isDefined(val)) return undefined;
...         
...     // test the passing case
...     if(validate.isPromise(val)){
.....         return undefined;
.....     }
...         
...     // if we got here, we have an error, so return an error message
...     return opts.message || this.message || 'is not a promise';
... };
[Function]
> // create a promise
undefined
> var p = Promise.resolve('thingys');
undefined
> 
> // should throw an error
undefined
> validate.single(p, {presence: true, promise: true});
Error: Use validate.async if you want support for promises
    at validate (/Users/bart/Documents/Temp/fromGitHub/validate.js/validate.js:33:17)
    at Function.single (/Users/bart/Documents/Temp/fromGitHub/validate.js/validate.js:202:14)
    at repl:1:10
    at ContextifyScript.Script.runInThisContext (vm.js:44:33)
    at REPLServer.defaultEval (repl.js:239:29)
    at bound (domain.js:301:14)
    at REPLServer.runBound [as eval] (domain.js:314:12)
    at REPLServer.onLine (repl.js:433:10)
    at emitOne (events.js:120:20)
    at REPLServer.emit (events.js:210:7)
> // should fail validation
undefined
> validate.single('stuff', {presence: true, promise: true}, {allowPromises: true});
[ 'is not a promise' ]
> // should pass validation
undefined
> validate.single(p, {presence: true, promise: true}, {allowPromises: true});
undefined
> 
```

I could also add the `promise` validator as a separate pull request?