### PR TITLE
Fix typo in changelog

### DIFF
--- a/index.html
+++ b/index.html
@@ -2450,7 +2450,7 @@ validate.result("foo".toUpperCase);
                 <b>Breaking!</b> The presence validator no longer rejects empty
                 values (empty strings, arrays, objects etc) per default.
                 The option <code>allowEmpty</code> can be set to false to
-                start passing them through.
+                prevent passing them through.
               </li>
               <li>
                 The numericality validator now allows negative numbers in strict


### PR DESCRIPTION
While updating to v0.12.0 and browsing through changelog I found this small typo.

If I understand it correctly, setting `allowEmpty: false` prevents passing empty values.