### PR TITLE
use xregexp to handle unicode alphabet

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "grunt-template-jasmine-istanbul": "0.4.0",
     "coveralls": "2.11.9"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "xregexp": "^4.1.1"
+  }
 }

--- a/validate.js
+++ b/validate.js
@@ -6,6 +6,7 @@
  * For all details and documentation:
  * http://validatejs.org/
  */
+ var XRegExp = require('xregexp');
 
 (function(exports, module, define) {
   "use strict";
@@ -1001,7 +1002,7 @@
       }
 
       if (v.isString(pattern)) {
-        pattern = new RegExp(options.pattern, options.flags);
+        pattern = XRegExp(options.pattern, options.flags);
       }
       match = pattern.exec(value);
       if (!match || match[0].length != value.length) {


### PR DESCRIPTION
Javascript RexExp doesn't handle unicode characters well - it doesn't contain 'Letter' unicode category. This PR solves it, now you can use '^//pL+$' to accept only unicode letters.