### PR TITLE
Exclusive attribute validation mode

### DIFF
--- a/specs/validate-spec.js
+++ b/specs/validate-spec.js
@@ -192,6 +192,16 @@ describe("validate", function() {
       ]);
     });
 
+    it("does not allow undeclared attributes in exclusive mode", function() {
+      var attrs = {name: "Nicklas", age: 23}
+        , globalOptions = {exclusive: true}
+        , constraints = {name: true};
+      expect(validate.runValidations(attrs, constraints, globalOptions)).toHaveItems([{
+        attribute: "age",
+        error: "is not permitted (exclusive mode)"
+      }]);
+    });
+
     it("allows the options for an attribute to be a function", function() {
       var options = {pass: {option1: "value1"}}
         , attrs = {name: "Nicklas"}

--- a/validate.js
+++ b/validate.js
@@ -80,6 +80,7 @@
     runValidations: function(attributes, constraints, options) {
       var results = []
         , attr
+        , constraint
         , validatorName
         , value
         , validators
@@ -89,6 +90,25 @@
 
       if (v.isDomElement(attributes) || v.isJqueryElement(attributes)) {
         attributes = v.collectFormValues(attributes);
+      }
+
+      // In 'exclusive' mode, make sure that there's a constraint for each and
+      // every attribute. Nested attribute names are matched as well.
+      if (options.exclusive === true) {
+        for (attr in attributes) {
+          var declared = false;
+          for (constraint in constraints) {
+            if (constraint === attr || constraint.indexOf(attr + ".") === 0) {
+              declared = true;
+            }
+          }
+          if (!declared) {
+            results.push({
+              attribute: attr,
+              error: "is not permitted (exclusive mode)",
+            });
+          }
+        }
       }
 
       // Loops through each constraints, finds the correct validator and run it.


### PR DESCRIPTION
Sometimes it makes sense to permit only those attributes which are explicitly declared within the ruleset. It makes validation stricter and prevents typos and unwanted values. This small feature helped us pinpoint bugs in our API output. It also works with custom validators (via global options) and nested attributes (to the extent validate.js supports them).

#### INPUT
```js
{
    name: "Nicklas",
    age: 23
}
```

#### CONSTRAINTS
```js
{
    name: true
}
```

#### RESULT

Output of `validate(input, constraints, { exclusive: true })`:

```js
{
    age: ['Age is not permitted (exclusive mode)']
}
```
