### PR TITLE
Support for data URIs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1852,6 +1852,11 @@ validate({myAttribute: true}, {myAttribute: {type: "customType"}});
                 local hostnames such as <code>10.0.1.1</code> or
                 <code>localhost</code>. The default is <code>false</code>.
               </li>
+              <li>
+                <b>allowDataUrl</b> - A boolean that if <code>true</code> allows
+                data URLs as defined in <a href="https://tools.ietf.org/html/rfc2397">RFC 2397</a>.
+                The default is <code>false</code>
+              </li>
             </ul>
             <pre><code class="javascript">validate({website: "http://google.com"}, {website: {url: true}});
 // =&gt; undefined
@@ -1881,6 +1886,19 @@ validate({website: "http://localhost"}, {
     }
   }
 });
+// =&gt; undefined
+
+validate({website: "data:,Hello%2C%20World!"}, {website: {url: true}});
+// =&gt; {"website": ["Website is not a valid url"]}
+
+validate({website: "data:,Hello%2C%20World!"}, {
+    website: {
+        url: {
+            allowDataUrl: true
+        }
+      }
+    }
+);
 // =&gt; undefined</code></pre>
           </div>
         </div>

--- a/specs/validators/url-spec.js
+++ b/specs/validators/url-spec.js
@@ -118,6 +118,20 @@ describe("validators.url", function() {
     expect(url("http://nicklas:password@localhost:4711/foo", {allowLocal: true})).not.toBeDefined();
   });
 
+  it("allows data urls", function () {
+    //Examples from https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+    expect(url("data:,Hello%2C%20World!", { allowDataUrl: true })).not.toBeDefined();
+    expect(url("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D", { allowDataUrl: true })).not.toBeDefined();
+    expect(url("data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E", { allowDataUrl: true })).not.toBeDefined();
+  });
+
+  it("fails data urls without the option", function () {
+    //Examples from https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+    expect(url("data:,Hello%2C%20World!", { allowDataUrl: false })).toBeDefined();
+    expect(url("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D", { allowDataUrl: false })).toBeDefined();
+    expect(url("data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E", { allowDataUrl: false })).toBeDefined();
+  });
+
   it("allows custom schemes option is set", function() {
     var options = {schemes: ['ftp', 'jdbc']};
     expect(url("ftp://foo.bar.com", options)).not.toBeDefined();

--- a/validate.js
+++ b/validate.js
@@ -1099,8 +1099,8 @@
 
       var message = options.message || this.message || "is not a valid url"
         , schemes = options.schemes || this.schemes || ['http', 'https']
-        , allowLocal = options.allowLocal || this.allowLocal || false;
-
+        , allowLocal = options.allowLocal || this.allowLocal || false
+        , allowDataUrl = options.allowDataUrl || this.allowDataUrl || false;
       if (!v.isString(value)) {
         return message;
       }
@@ -1148,6 +1148,14 @@
         // resource path
         "(?:[/?#]\\S*)?" +
       "$";
+
+      if (allowDataUrl) {
+        // RFC 2397
+        var mediaType = "\\w+\\/[-+.\\w]+(?:;[\\w=]+)*";
+        var urlchar = "[A-Za-z0-9-_.!~\\*'();\\/?:@&=+$,%]*";
+        var dataurl = "data:(?:"+mediaType+")?(?:;base64)?,"+urlchar;
+        regex = "(?:"+regex+")|(?:^"+dataurl+"$)";
+      }
 
       var PATTERN = new RegExp(regex, 'i');
       if (!PATTERN.exec(value)) {


### PR DESCRIPTION
This adds support for data URLs when validating URLs. It is useful in the cases where a user needs to validate such a URL when it is provided e.g. as the src attribute of an image. 