### PR TITLE
feature: make a best guess at prettifying object that have no prototype

### DIFF
--- a/specs/validate-helpers-spec.js
+++ b/specs/validate-helpers-spec.js
@@ -202,6 +202,25 @@ describe("validate", function() {
       expect(validate.prettify(object)).toEqual("Custom string");
     });
 
+    it("tries to stringify objects that don't implement toString", function() {
+      var object = Object.create(null);
+
+      object.name = "Foo Bar";
+
+      expect(validate.prettify(object)).toEqual("{\"name\":\"Foo Bar\"}");
+    });
+
+    it("throws an error when trying to parse cyclical structures", function() {
+      var object = Object.create(null);
+
+      object.name = "Foo Bar";
+      object.cycle = object;
+
+      expect(function () { 
+        return validate.prettify(object); 
+      }).toThrow();
+    });
+
     it("doesn't allow too many decimals", function() {
       expect(validate.prettify(4711)).toEqual("4711");
       expect(validate.prettify(4711.2)).toEqual("4711.2");

--- a/validate.js
+++ b/validate.js
@@ -387,6 +387,10 @@
       }
 
       if (v.isObject(str)) {
+        if (!v.isDefined(str.toString)) {
+          return JSON.stringify(str);
+        }
+
         return str.toString();
       }
 


### PR DESCRIPTION
Hello!

I'm working with a third party library that initializes objects using `Object.create(null)` (graphql). The result is that these objects do not have prototypes and do not implement `toString`. This becomes an issue when trying to validate object using your (otherwise wonderful) library.

I have added a line that checks whether a given object implements `toString` and tries to fall back on `JSON.stringify`. If `stringify` encounters the dreaded cyclic structure, then at that point I would say maybe the user needs to rethink things.

I've added two tests to capture this new behaviour. I think that this is not a breaking change. Please let me know if you have any questions or feedback!

For some background on this issue, see discussion here: https://github.com/graphql/express-graphql/issues/177