### PR TITLE
add unequalTo numericality constrainst

### DIFF
--- a/index.html
+++ b/index.html
@@ -1658,6 +1658,8 @@ validate(values, constraints);
               <dd>The input has to be at least this value. The error message is <i>must be greater than or equal to %{count}</i></dd>
               <dt>equalTo</dt>
               <dd>The input has to be exactly this value. The error message is <i>must be equal to %{count}</i></dd>
+              <dt>unequalTo</dt>
+              <dd>The input has to be unequal to this value. The error message is <i>must be unequal to %{count}</i></dd>
               <dt>lessThanOrEqualTo</dt>
               <dd>The input can be this value at the most. The error message is <i>must be less than or equal to %{count}</i></dd>
               <dt>lessThan</dt>
@@ -1680,6 +1682,7 @@ validate(values, constraints);
               <li><code>notGreaterThan</code></li>
               <li><code>notGreaterThanOrEqualTo</code></li>
               <li><code>notEqualTo</code></li>
+              <li><code>notUnequalTo</code></li>
               <li><code>notLessThan</code></li>
               <li><code>notLessThanOrEqualTo</code></li>
               <li><code>notDivisibleBy</code></li>

--- a/specs/validators/numericality-spec.js
+++ b/specs/validators/numericality-spec.js
@@ -12,6 +12,7 @@ describe("validators.numericality", function() {
     delete n.notGreaterThan;
     delete n.notGreaterThanOrEqualTo;
     delete n.notEqualTo;
+    delete n.notUnequalTo;
     delete n.notLessThan;
     delete n.notLessThanOrEqualTo;
     delete n.notDivisibleBy;
@@ -157,6 +158,30 @@ describe("validators.numericality", function() {
     it("allows for a custom message", function() {
       var expected = "custom message";
       expect(numericality(3.13, {equalTo: 3.14, notEqualTo:expected})).toEqual([expected]);
+    });
+  });
+
+  describe("unequalTo", function() {
+    it("allows numbers that are unequal to", function() {
+      expect(numericality(2.72, {unequalTo: 2.73})).not.toBeDefined();
+    });
+
+    it("doesn't allow numbers that are equal", function() {
+      var expected = ["must be unequal to 2.72"];
+      expect(numericality(2.72, {unequalTo: 2.72})).toEqual(expected);
+    });
+
+    it("allows for a default message", function() {
+      validate.validators.numericality.message = "default generic message";
+      expect(numericality(3.13, {unequalTo: 3.13})).toEqual(["default generic message"]);
+
+      validate.validators.numericality.notUnequalTo = "default message";
+      expect(numericality(3.13, {unequalTo: 3.13})).toEqual(["default message"]);
+    });
+
+    it("allows for a custom message", function() {
+      var expected = "custom message";
+      expect(numericality(3.13, {unequalTo: 3.13, notUnequalTo:expected})).toEqual([expected]);
     });
   });
 

--- a/validate.js
+++ b/validate.js
@@ -836,6 +836,7 @@
             greaterThan:          function(v, c) { return v > c; },
             greaterThanOrEqualTo: function(v, c) { return v >= c; },
             equalTo:              function(v, c) { return v === c; },
+            unequalTo:            function(v, c) { return v !== c; },
             lessThan:             function(v, c) { return v < c; },
             lessThanOrEqualTo:    function(v, c) { return v <= c; },
             divisibleBy:          function(v, c) { return v % c === 0; }


### PR DESCRIPTION
Hello! This adds support for inequality check when validating numericality. 

Example:

```
const constrainsts = {
  value: {
    numericality: {
      unequalTo: 10
    }
  }
};

validate({value: 10}, constrainsts); // => {value: ["Value must be unequal to 10"]}
```