### PR TITLE
Add custom attribute label validator

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -653,7 +653,7 @@
         if (error[0] === '^') {
           error = error.slice(1);
         } else if (options.fullMessages !== false) {
-          error = errorInfo.attributeLabel || v.capitalize(prettify(errorInfo.attribute)) + " " + error;
+          error = (errorInfo.attributeLabel || v.capitalize(prettify(errorInfo.attribute))) + " " + error;
         }
         error = error.replace(/\\\^/g, "^");
         error = v.format(error, {

--- a/validate.js
+++ b/validate.js
@@ -653,7 +653,7 @@
         if (error[0] === '^') {
           error = error.slice(1);
         } else if (options.fullMessages !== false) {
-          error = v.capitalize(prettify(errorInfo.attributeLabel || errorInfo.attribute)) + " " + error;
+          error = errorInfo.attributeLabel || v.capitalize(prettify(errorInfo.attribute)) + " " + error;
         }
         error = error.replace(/\\\^/g, "^");
         error = v.format(error, {

--- a/validate.js
+++ b/validate.js
@@ -102,6 +102,9 @@
         validators = v.result(constraints[attr], value, attributes, attr, options, constraints);
 
         for (validatorName in validators) {
+          if (validatorName === 'attributeLabel') (
+            continue;
+          )
           validator = v.validators[validatorName];
 
           if (!validator) {
@@ -121,6 +124,7 @@
           }
           results.push({
             attribute: attr,
+            attributeLabel: validators.attributeLabel,
             value: value,
             validator: validatorName,
             globalOptions: options,
@@ -649,7 +653,7 @@
         if (error[0] === '^') {
           error = error.slice(1);
         } else if (options.fullMessages !== false) {
-          error = v.capitalize(prettify(errorInfo.attribute)) + " " + error;
+          error = v.capitalize(prettify(errorInfo.attributeLabel || errorInfo.attribute)) + " " + error;
         }
         error = error.replace(/\\\^/g, "^");
         error = v.format(error, {

--- a/validate.js
+++ b/validate.js
@@ -102,9 +102,9 @@
         validators = v.result(constraints[attr], value, attributes, attr, options, constraints);
 
         for (validatorName in validators) {
-          if (validatorName === 'attributeLabel') (
+          if (validatorName === 'attributeLabel') {
             continue;
-          )
+          }
           validator = v.validators[validatorName];
 
           if (!validator) {


### PR DESCRIPTION
Adds support for using attribute labels to be displayed in the error message instead of prettified attribute. This enables error message localisation. Usage:

```
const validationConstraints = {
  age: {
    attributeLabel: "The user age",
    presence: true,
    type: "string"
  }
};
```
```
Output: The user age is required
```

Changes:
- attributeLabel validator is bypassed in validator check loop.
- If errorInfo attributeLabel is set in convertErrorMessages, it will be prepended in place of prettified errorInfo attribute.